### PR TITLE
Jump to method from menu navigation

### DIFF
--- a/publish.js
+++ b/publish.js
@@ -378,12 +378,20 @@ function buildMemberNav(items, itemHeading, itemsSeen, linktoFn) {
                         if (docdash.static === false && method.scope === 'static') return;
                         if (docdash.private === false && method.access === 'private') return;
 
-                        itemsNav += "<li data-type='method'";
+                        var navItem = '';
+                        var navItemLink = linkto(method.longname, method.name);
+                        var strNewLink = '.html#' + method.name;
+
+                        navItemLink = navItemLink.replace('.html', strNewLink);
+
+                        navItem += "<li data-type='method'";
                         if(docdash.collapse)
-                            itemsNav += " style='display: none;'";
-                        itemsNav += ">";
-                        itemsNav += linkto(method.longname, method.name);
-                        itemsNav += "</li>";
+                            navItem += " style='display: none;'";
+                        navItem += ">";
+                        navItem += navItemLink;
+                        navItem += "</li>";
+
+                        itemsNav += navItem;
                     });
 
                     itemsNav += "</ul>";


### PR DESCRIPTION
The methods are shown in the menu as subitem of the class. However, the link doesn't have a navigation to jump to the method. This code makes that possible.